### PR TITLE
docs: A new contributor graph that evaluates community activities from all dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ TDesign 适配移动端的组件库，适合在 React 16.x 技术栈项目中使
 # 开源协议
 
 TDesign 遵循 [MIT 协议](https://github.com/Tencent/tdesign-mobile-react/LICENSE)。
+
+# 贡献成员
+
+感谢所有为该项目添砖加瓦的贡献者
+
+<a href="https://openomy.app/github/tencent/tdesign-mobile-react" target="_blank" style="display: block; width: 100%;" align="center">
+  <img src="https://openomy.app/svg?repo=tencent/tdesign-mobile-react&chart=bubble&latestMonth=12" target="_blank" alt="Contribution Leaderboard" style="display: block; width: 100%;" />
+ </a>


### PR DESCRIPTION
Hi Tencent/tdesign Community

tdesign-mobile-react is a vibrant open-source community where its products and frameworks are loved by lots of users and developers. As people use it, they contribute by raising issues, engaging in discussions, or directly contributing code, all of which help in continuously improving tdesign-mobile-react.

However, GitHub's default contributor list simply enumerates users who have committed code, failing to proportionately reflect the broader range of community contributors.

Therefore, we have designed a new chart that showcases active contributors from three perspectives: issues, PRs, and discussions. This is similar to embedding star-history within the README:

![Tencent/tdesign-mobile-react](https://www.openomy.app/svg?repo=Tencent/tdesign-mobile-react&chart=bubble&latestMonth=12)

By clicking on the link, you can view the specific contributions made by each individual: 

[Tencent/tdesign-mobile-react](https://www.openomy.app/github/Tencent/tdesign-mobile-react)

Currently, we have received recognition from communities such as [Ant Design (antd)]([GitHub - ant-design/ant-design: An enterprise-class UI design language and React UI library](https://github.com/ant-design/ant-design)). We aim to introduce this solution to more open-source communities and actively seek feedback for ongoing improvement.

We would greatly appreciate it if you could merge this PR. However, if you feel that the style is not appropriate or you don't like this approach, that's perfectly okay as well!