### PR TITLE
fix(guide): 修复popover下展示位置错误问题

### DIFF
--- a/src/popover/Popover.tsx
+++ b/src/popover/Popover.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState, forwardRef, useImperativeHandle } from 'react';
 import { createPopper, Placement } from '@popperjs/core';
 import { useClickAway } from 'ahooks';
 import { CSSTransition } from 'react-transition-group';
@@ -14,7 +14,11 @@ import useDefault from '../_util/useDefault';
 
 export interface PopoverProps extends TdPopoverProps, StyledProps {}
 
-const Popover: React.FC<PopoverProps> = (props) => {
+export interface PopoverExposeRef {
+  updatePopper: () => null | void;
+}
+
+const Popover = forwardRef<PopoverExposeRef, PopoverProps>((props, ref) => {
   const {
     closeOnClickOutside,
     className,
@@ -184,6 +188,10 @@ const Popover: React.FC<PopoverProps> = (props) => {
     </div>
   );
 
+  useImperativeHandle(ref, () => ({
+    updatePopper,
+  }));
+
   return (
     <>
       <div
@@ -213,7 +221,7 @@ const Popover: React.FC<PopoverProps> = (props) => {
       </CSSTransition>
     </>
   );
-};
+});
 
 Popover.displayName = 'Popover';
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

fix https://github.com/Tencent/tdesign-mobile-react/issues/686

1. 判空，xxxRef.current
2. 增加对 popover 组件的主动调用，防止展示位置不对

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Guide): 修复 `popover` 下展示位置错误问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
