### PR TITLE
feat(calendar): support allowSameDay prop

### DIFF
--- a/src/calendar/CalendarTemplate.tsx
+++ b/src/calendar/CalendarTemplate.tsx
@@ -162,9 +162,12 @@ const CalendarTemplate = forwardRef<HTMLDivElement, CalendarProps>((_props, ref)
       if (props.type === 'range') {
         if (Array.isArray(selectedDate)) {
           const [startDate, endDate] = selectedDate;
+          const compareWithStart = startDate && isSameDate({ year, month, date }, startDate);
+          const compareWithEnd = endDate && isSameDate({ year, month, date }, endDate);
 
-          if (startDate && isSameDate({ year, month, date }, startDate)) return 'start';
-          if (endDate && isSameDate({ year, month, date }, endDate)) return 'end';
+          if (compareWithStart && compareWithEnd && props.allowSameDay) return 'start-end';
+          if (compareWithStart) return 'start';
+          if (compareWithEnd) return 'end';
           if (
             startDate &&
             endDate &&
@@ -248,7 +251,7 @@ const CalendarTemplate = forwardRef<HTMLDivElement, CalendarProps>((_props, ref)
     switch (props.type) {
       case 'range': {
         if (Array.isArray(selectedDate)) {
-          if (selectedDate.length === 1) {
+          if (selectedDate.length === 1 && selected >= selectedDate[0]) {
             newSelected = selectedDate[0] > selected ? [selected] : [selectedDate[0], selected];
           } else {
             newSelected = [selected];

--- a/src/calendar/calendar.en-US.md
+++ b/src/calendar/calendar.en-US.md
@@ -7,27 +7,28 @@
 name | type | default | description | required
 -- | -- | -- | -- | --
 className | String | - | className of component | N
-style | Object | - | CSS(Cascading Style Sheets)，Typescript：`React.CSSProperties` | N
+style | Object | - | CSS(Cascading Style Sheets)，Typescript: `React.CSSProperties` | N
+allowSameDay | Boolean | false | \- | N
 autoClose | Boolean | true | \- | N
-confirmBtn | TNode | '' | Typescript：`string \| ButtonProps \| TNode \| null`，[Button API Documents](./button?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/blob/develop/src/common.ts)。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts) | N
+confirmBtn | TNode | '' | Typescript: `string \| ButtonProps \| TNode \| null`，[Button API Documents](./button?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/blob/develop/src/common.ts)。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts) | N
 firstDayOfWeek | Number | 0 | \- | N
-format | Function | - | Typescript：`CalendarFormatType ` `type CalendarFormatType = (day: TDate) => TDate` `type TDateType = 'selected' \| 'disabled' \| 'start' \| 'centre' \| 'end' \| ''` `interface TDate { date: Date; day: number; type: TDateType; className?: string; prefix?: string; suffix?: string;}`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts) | N
-maxDate | Number / Date | - | Typescript：` number \| Date` | N
-minDate | Number / Date | - | Typescript：` number \| Date` | N
+format | Function | - | Typescript: `CalendarFormatType ` `type CalendarFormatType = (day: TDate) => TDate` `type TDateType = 'selected' \| 'disabled' \| 'start' \| 'start-end' \|'centre' \| 'end' \| ''` `interface TDate { date: Date; day: number; type: TDateType; className?: string; prefix?: string; suffix?: string;}`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts) | N
+maxDate | Number / Date | - | Typescript: ` number \| Date` | N
+minDate | Number / Date | - | Typescript: ` number \| Date` | N
 readonly | Boolean | - | `0.16.0` | N
 switchMode | String | none | `0.16.0`。options: none/month/year-month | N
-title | TNode | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/blob/develop/src/common.ts) | N
-type | String | 'single' | options: single/multiple/range | N
+title | TNode | - | Typescript: `string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/blob/develop/src/common.ts) | N
+type | String | single | options: single/multiple/range | N
 usePopup | Boolean | true | \- | N
-value | Number / Array / Date | - | Typescript：`CalendarValue` `type CalendarValue = TCalendarValue \| TCalendarValue[]` `type TCalendarValue = number \| Date`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts) | N
-defaultValue | Number / Array / Date | - | uncontrolled property。Typescript：`CalendarValue` `type CalendarValue = TCalendarValue \| TCalendarValue[]` `type TCalendarValue = number \| Date`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts) | N
+value | Number / Array / Date | - | Typescript: `CalendarValue` `type CalendarValue = TCalendarValue \| TCalendarValue[]` `type TCalendarValue = number \| Date`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts) | N
+defaultValue | Number / Array / Date | - | uncontrolled property。Typescript: `CalendarValue` `type CalendarValue = TCalendarValue \| TCalendarValue[]` `type TCalendarValue = number \| Date`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts) | N
 visible | Boolean | false | \- | N
-onChange | Function |  | Typescript：`(value: CalendarValue) => void`<br/> | N
-onClose | Function |  | Typescript：`(trigger: CalendarTrigger) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts)。<br/>`type CalendarTrigger = 'close-btn' \| 'confirm-btn' \| 'overlay' \| 'auto-close'`<br/> | N
-onConfirm | Function |  | Typescript：`(value: CalendarValue) => void`<br/> | N
-onPanelChange | Function |  | Typescript：`(context: { year: number, month: number }) => void`<br/>`0.16.0` | N
-onScroll | Function |  | Typescript：`(context: {e: React.UIEvent}) => void`<br/>`0.16.0`。triggered when scrolling | N
-onSelect | Function |  | Typescript：`(value: Date) => void`<br/> | N
+onChange | Function |  | Typescript: `(value: CalendarValue) => void`<br/> | N
+onClose | Function |  | Typescript: `(trigger: CalendarTrigger) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts)。<br/>`type CalendarTrigger = 'close-btn' \| 'confirm-btn' \| 'overlay' \| 'auto-close'`<br/> | N
+onConfirm | Function |  | Typescript: `(value: CalendarValue) => void`<br/> | N
+onPanelChange | Function |  | Typescript: `(context: { year: number, month: number }) => void`<br/>`0.16.0` | N
+onScroll | Function |  | Typescript: `(context: {e: React.UIEvent}) => void`<br/>`0.16.0`。triggered when scrolling | N
+onSelect | Function |  | Typescript: `(value: Date) => void`<br/> | N
 
 ### CSS Variables
 

--- a/src/calendar/calendar.md
+++ b/src/calendar/calendar.md
@@ -8,16 +8,17 @@
 -- | -- | -- | -- | --
 className | String | - | 类名 | N
 style | Object | - | 样式，TS 类型：`React.CSSProperties` | N
+allowSameDay | Boolean | false | 是否允许区间选择日历的起止时间相同，仅当 `type='range'` 时有效 | N
 autoClose | Boolean | true | 自动关闭；在点击关闭按钮、确认按钮、遮罩层时自动关闭，不需要手动设置 visible | N
 confirmBtn | TNode | '' | 确认按钮。值为 null 则不显示确认按钮。值类型为字符串，则表示自定义按钮文本，值类型为 Object 则表示透传 Button 组件属性。TS 类型：`string \| ButtonProps \| TNode \| null`，[Button API Documents](./button?tab=api)。[通用类型定义](https://github.com/Tencent/tdesign-mobile-react/blob/develop/src/common.ts)。[详细类型定义](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts) | N
 firstDayOfWeek | Number | 0 | 第一天从星期几开始，默认 0 = 周日 | N
-format | Function | - | 用于格式化日期的函数。TS 类型：`CalendarFormatType ` `type CalendarFormatType = (day: TDate) => TDate` `type TDateType = 'selected' \| 'disabled' \| 'start' \| 'centre' \| 'end' \| ''` `interface TDate { date: Date; day: number; type: TDateType; className?: string; prefix?: string; suffix?: string;}`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts) | N
+format | Function | - | 用于格式化日期的函数。TS 类型：`CalendarFormatType ` `type CalendarFormatType = (day: TDate) => TDate` `type TDateType = 'selected' \| 'disabled' \| 'start' \| 'start-end' \|'centre' \| 'end' \| ''` `interface TDate { date: Date; day: number; type: TDateType; className?: string; prefix?: string; suffix?: string;}`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts) | N
 maxDate | Number / Date | - | 最大可选的日期，不传则默认半年后。TS 类型：` number \| Date` | N
 minDate | Number / Date | - | 最小可选的日期，不传则默认今天。TS 类型：` number \| Date` | N
 readonly | Boolean | - | `0.16.0`。是否只读，只读状态下不能选择日期 | N
 switchMode | String | none | `0.16.0`。切换模式。 `none` 表示平铺展示所有月份； `month` 表示支持按月切换， `year-month` 表示既按年切换，也支持按月切换。可选项：none/month/year-month | N
 title | TNode | - | 标题，不传默认为“请选择日期”。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-mobile-react/blob/develop/src/common.ts) | N
-type | String | 'single' | 日历的选择类型，single = 单选；multiple = 多选; range = 区间选择。可选项：single/multiple/range | N
+type | String | single | 日历的选择类型，single = 单选；multiple = 多选; range = 区间选择。可选项：single/multiple/range | N
 usePopup | Boolean | true | 是否使用弹出层包裹日历 | N
 value | Number / Array / Date | - | 当前选择的日期，不传则默认今天，当 type = multiple 或 range 时传入数组。TS 类型：`CalendarValue` `type CalendarValue = TCalendarValue \| TCalendarValue[]` `type TCalendarValue = number \| Date`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts) | N
 defaultValue | Number / Array / Date | - | 当前选择的日期，不传则默认今天，当 type = multiple 或 range 时传入数组。非受控属性。TS 类型：`CalendarValue` `type CalendarValue = TCalendarValue \| TCalendarValue[]` `type TCalendarValue = number \| Date`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/calendar/type.ts) | N

--- a/src/calendar/defaultProps.ts
+++ b/src/calendar/defaultProps.ts
@@ -5,6 +5,7 @@
 import { TdCalendarProps } from './type';
 
 export const calendarDefaultProps: TdCalendarProps = {
+  allowSameDay: false,
   autoClose: true,
   confirmBtn: '',
   firstDayOfWeek: 0,

--- a/src/calendar/type.ts
+++ b/src/calendar/type.ts
@@ -9,6 +9,11 @@ import { TNode } from '../common';
 
 export interface TdCalendarProps {
   /**
+   * 是否允许区间选择日历的起止时间相同，仅当 `type='range'` 时有效
+   * @default false
+   */
+  allowSameDay?: boolean;
+  /**
    * 自动关闭；在点击关闭按钮、确认按钮、遮罩层时自动关闭，不需要手动设置 visible
    * @default true
    */
@@ -50,7 +55,7 @@ export interface TdCalendarProps {
   title?: TNode;
   /**
    * 日历的选择类型，single = 单选；multiple = 多选; range = 区间选择
-   * @default 'single'
+   * @default single
    */
   type?: 'single' | 'multiple' | 'range';
   /**
@@ -99,7 +104,7 @@ export interface TdCalendarProps {
 
 export type CalendarFormatType = (day: TDate) => TDate;
 
-export type TDateType = 'selected' | 'disabled' | 'start' | 'centre' | 'end' | '';
+export type TDateType = 'selected' | 'disabled' | 'start' | 'start-end' | 'centre' | 'end' | '';
 
 export interface TDate {
   date: Date;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-miniprogram/pull/4045
- https://github.com/TDesignOteam/tdesign-api/pull/774
- https://github.com/Tencent/tdesign-common/pull/2333
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Calendar): 新增 `allowSameDay` 属性，允许 type='range' 场景的起止时间相同

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
