### PR TITLE
feat(Indexes): support showFullIndex prop

### DIFF
--- a/src/indexes/Indexes.tsx
+++ b/src/indexes/Indexes.tsx
@@ -26,10 +26,8 @@ interface ChildNodes {
 }
 
 const Indexes: React.FC<IndexesProps> = (props) => {
-  const { indexList, className, style, sticky, stickyOffset, children, onChange, onSelect } = useDefaultProps(
-    props,
-    indexesDefaultProps,
-  );
+  const { indexList, className, style, sticky, stickyOffset, children, onChange, onSelect, showFullIndex } =
+    useDefaultProps(props, indexesDefaultProps);
 
   const indexesClass = usePrefixClass('indexes');
 
@@ -214,24 +212,27 @@ const Indexes: React.FC<IndexesProps> = (props) => {
         ref={indexesRef}
       >
         <div ref={sidebarRef} className={`${indexesClass}__sidebar`}>
-          {indexListMemo.map((listItem) => (
-            <div
-              className={cls(`${indexesClass}__sidebar-item`, {
-                [`${indexesClass}__sidebar-item--active`]: activeSidebar === listItem,
-              })}
-              key={listItem}
-              data-index={listItem}
-              onClick={(e) => {
-                e.preventDefault();
-                handleSidebarItemClick(listItem);
-              }}
-            >
-              {listItem}
-              {showSidebarTip && activeSidebar === listItem && (
-                <div className={`${indexesClass}__sidebar-tips`}>{activeSidebar}</div>
-              )}
-            </div>
-          ))}
+          {indexListMemo.map((listItem) => {
+            const text = showFullIndex ? listItem : String(listItem).charAt(0);
+            return (
+              <div
+                className={cls(`${indexesClass}__sidebar-item`, {
+                  [`${indexesClass}__sidebar-item--active`]: activeSidebar === listItem,
+                })}
+                key={listItem}
+                data-index={listItem}
+                onClick={(e) => {
+                  e.preventDefault();
+                  handleSidebarItemClick(listItem);
+                }}
+              >
+                {text}
+                {showSidebarTip && activeSidebar === listItem && (
+                  <div className={`${indexesClass}__sidebar-tips`}>{activeSidebar}</div>
+                )}
+              </div>
+            );
+          })}
         </div>
         {parseTNode(children)}
       </div>

--- a/src/indexes/_example/custom.tsx
+++ b/src/indexes/_example/custom.tsx
@@ -59,7 +59,7 @@ export default function IndexesDemo({ goHome }) {
           goHome();
         }}
       />
-      <Indexes indexList={indexList} onChange={change} onSelect={select}>
+      <Indexes showFullIndex indexList={indexList} onChange={change} onSelect={select}>
         {list.map((item) => (
           <Fragment key={item.index}>
             <IndexesAnchor index={item.index}>

--- a/src/indexes/defaultProps.ts
+++ b/src/indexes/defaultProps.ts
@@ -4,4 +4,4 @@
 
 import { TdIndexesProps } from './type';
 
-export const indexesDefaultProps: TdIndexesProps = { sticky: true, stickyOffset: 0 };
+export const indexesDefaultProps: TdIndexesProps = { showFullIndex: false, sticky: true, stickyOffset: 0 };

--- a/src/indexes/indexes.en-US.md
+++ b/src/indexes/indexes.en-US.md
@@ -9,7 +9,6 @@ name | type | default | description | required
 className | String | - | className of component | N
 style | Object | - | CSS(Cascading Style Sheets)，Typescript: `React.CSSProperties` | N
 indexList | Array | - | Typescript: `Array<string \| number>` | N
-list | Array | [] | `deprecated`。Typescript: `ListItem[] ` `interface ListItem { title: string;  index: string;  children: { title: string; [key: string]: any} [] }`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/indexes/type.ts) | N
 showFullIndex | Boolean | false | `0.21.4`。Typescript: `Boolean` | N
 sticky | Boolean | true | Typescript: `Boolean` | N
 stickyOffset | Number | 0 | \- | N

--- a/src/indexes/indexes.en-US.md
+++ b/src/indexes/indexes.en-US.md
@@ -7,12 +7,14 @@
 name | type | default | description | required
 -- | -- | -- | -- | --
 className | String | - | className of component | N
-style | Object | - | CSS(Cascading Style Sheets)，Typescript：`React.CSSProperties` | N
-indexList | Array | - | Typescript：`(string \| number)[]` | N
-sticky | Boolean | true | Typescript：`Boolean` | N
+style | Object | - | CSS(Cascading Style Sheets)，Typescript: `React.CSSProperties` | N
+indexList | Array | - | Typescript: `Array<string \| number>` | N
+list | Array | [] | `deprecated`。Typescript: `ListItem[] ` `interface ListItem { title: string;  index: string;  children: { title: string; [key: string]: any} [] }`。[see more ts definition](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/indexes/type.ts) | N
+showFullIndex | Boolean | false | `0.21.4`。Typescript: `Boolean` | N
+sticky | Boolean | true | Typescript: `Boolean` | N
 stickyOffset | Number | 0 | \- | N
-onChange | Function |  | Typescript：`(index: string \| number) => void`<br/> | N
-onSelect | Function |  | Typescript：`(index: string \| number) => void`<br/> | N
+onChange | Function |  | Typescript: `(index: string \| number) => void`<br/> | N
+onSelect | Function |  | Typescript: `(index: string \| number) => void`<br/> | N
 
 
 ### IndexesAnchor Props
@@ -20,13 +22,13 @@ onSelect | Function |  | Typescript：`(index: string \| number) => void`<br/> |
 name | type | default | description | required
 -- | -- | -- | -- | --
 className | String | - | className of component | N
-style | Object | - | CSS(Cascading Style Sheets)，Typescript：`React.CSSProperties` | N
+style | Object | - | CSS(Cascading Style Sheets)，Typescript: `React.CSSProperties` | N
 index | String / Number | - | \- | N
 
 ### CSS Variables
 
 The component provides the following CSS variables, which can be used to customize styles.
-Name | Default Value | Description 
+Name | Default Value | Description
 -- | -- | --
 --td-indexes-sidebar-active-bg-color | @brand-color | -
 --td-indexes-sidebar-active-color | @text-color-anti | -

--- a/src/indexes/indexes.md
+++ b/src/indexes/indexes.md
@@ -9,7 +9,6 @@
 className | String | - | 类名 | N
 style | Object | - | 样式，TS 类型：`React.CSSProperties` | N
 indexList | Array | - | 索引字符列表。不传默认 `A-Z`。TS 类型：`Array<string \| number>` | N
-list | Array | [] | 已废弃。索引列表的列表数据。每个元素包含三个子元素，index(string)：索引值，例如1，2，3，...或A，B，C等；title(string): 索引标题，可不填将默认设为索引值；children(Array<{title: string}>): 子元素列表，title为子元素的展示文案。TS 类型：`ListItem[] ` `interface ListItem { title: string;  index: string;  children: { title: string; [key: string]: any} [] }`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/indexes/type.ts) | N
 showFullIndex | Boolean | false | `0.21.4`。是否显示完整的索引内容，默认只显示首字符。TS 类型：`Boolean` | N
 sticky | Boolean | true | 索引是否吸顶，默认为true。TS 类型：`Boolean` | N
 stickyOffset | Number | 0 | 锚点吸顶时与顶部的距离	 | N

--- a/src/indexes/indexes.md
+++ b/src/indexes/indexes.md
@@ -8,7 +8,9 @@
 -- | -- | -- | -- | --
 className | String | - | 类名 | N
 style | Object | - | 样式，TS 类型：`React.CSSProperties` | N
-indexList | Array | - | 索引字符列表。不传默认 `A-Z`。TS 类型：`(string \| number)[]` | N
+indexList | Array | - | 索引字符列表。不传默认 `A-Z`。TS 类型：`Array<string \| number>` | N
+list | Array | [] | 已废弃。索引列表的列表数据。每个元素包含三个子元素，index(string)：索引值，例如1，2，3，...或A，B，C等；title(string): 索引标题，可不填将默认设为索引值；children(Array<{title: string}>): 子元素列表，title为子元素的展示文案。TS 类型：`ListItem[] ` `interface ListItem { title: string;  index: string;  children: { title: string; [key: string]: any} [] }`。[详细类型定义](https://github.com/Tencent/tdesign-mobile-react/tree/develop/src/indexes/type.ts) | N
+showFullIndex | Boolean | false | `0.21.4`。是否显示完整的索引内容，默认只显示首字符。TS 类型：`Boolean` | N
 sticky | Boolean | true | 索引是否吸顶，默认为true。TS 类型：`Boolean` | N
 stickyOffset | Number | 0 | 锚点吸顶时与顶部的距离	 | N
 onChange | Function |  | TS 类型：`(index: string \| number) => void`<br/>索引发生变更时触发事件 | N
@@ -26,7 +28,7 @@ index | String / Number | - | 索引字符 | N
 ### CSS Variables
 
 组件提供了下列 CSS 变量，可用于自定义样式。
-名称 | 默认值 | 描述 
+名称 | 默认值 | 描述
 -- | -- | --
 --td-indexes-sidebar-active-bg-color | @brand-color | -
 --td-indexes-sidebar-active-color | @text-color-anti | -

--- a/src/indexes/type.ts
+++ b/src/indexes/type.ts
@@ -8,7 +8,12 @@ export interface TdIndexesProps {
   /**
    * 索引字符列表。不传默认 `A-Z`
    */
-  indexList?: (string | number)[];
+  indexList?: Array<string | number>;
+  /**
+   * 是否显示完整的索引内容，默认只显示首字符
+   * @default false
+   */
+  showFullIndex?: Boolean;
   /**
    * 索引是否吸顶，默认为true
    * @default true


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

### 相关 PRs
https://github.com/Tencent/tdesign-miniprogram/pull/4405
https://github.com/TDesignOteam/tdesign-api/pull/846
https://github.com/Tencent/tdesign-common/pull/2468

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Indexes): 新增 `showFullIndex` 属性，表示是否显示完整的索引内容，默认显示首字符
- fix(Indexes): 修复气泡与右侧索引列表间距错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
