### PR TITLE
chore: update rollup config

### DIFF
--- a/script/rollup.config.js
+++ b/script/rollup.config.js
@@ -33,6 +33,7 @@ const inputList = [
   '!src/**/_example',
   '!src/**/*.d.ts',
   '!src/**/__tests__',
+  '!src/**/node_modules',
 ];
 
 const getPlugins = ({


### PR DESCRIPTION
### 背景
- 项目本地运行 npm run build 报错，错误地包含了 src/_common/node_modules/ 目录下的测试文件（.test-d.ts），这些文件本不应参与构建
```
[!] (plugin babel) SyntaxError: /Users/anlyyao/Documents/work/TDesign/tdesign-mobile-react/src/_common/node_modules/rfdc/index.test-d.ts: `import rfdc = require(...);` is only supported when compiling modules to CommonJS.
Please consider using `import rfdc from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
```