### PR TITLE
fix(Message): fix content not displayed when passing a string to Message.info/success/warning/error

### DIFF
--- a/src/message/methods.tsx
+++ b/src/message/methods.tsx
@@ -21,12 +21,13 @@ function destroy(context: Element, root: Element) {
   }
 }
 
-const createMessage = (props, theme?: MessageThemeList) => {
+const createMessage = (props: MessageActionOptionsType | string, theme?: MessageThemeList) => {
+  const normalizedProps = typeof props === 'string' ? { content: props } : props;
   const config = {
     ...messageDefaultProps,
     visible: true,
     context: isBrowser ? document.body : null,
-    ...props,
+    ...normalizedProps,
   };
   const { context } = config;
   if (!context) {
@@ -52,9 +53,9 @@ const closeAll = () => {
 };
 
 export default {
-  info: (props: MessageActionOptionsType) => createMessage(props, 'info'),
-  success: (props: MessageActionOptionsType) => createMessage(props, 'success'),
-  warning: (props: MessageActionOptionsType) => createMessage(props, 'warning'),
-  error: (props: MessageActionOptionsType) => createMessage(props, 'error'),
+  info: (props: MessageActionOptionsType | string) => createMessage(props, 'info'),
+  success: (props: MessageActionOptionsType | string) => createMessage(props, 'success'),
+  warning: (props: MessageActionOptionsType | string) => createMessage(props, 'warning'),
+  error: (props: MessageActionOptionsType | string) => createMessage(props, 'error'),
   closeAll,
 };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Message): 修复 `Message.info/success/warning/error` 直接传入字符串时文案不显示的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
