### PR TITLE
fix(PullDownRefresh): fix refresh event always being triggered twice

### DIFF
--- a/src/pull-down-refresh/PullDownRefresh.tsx
+++ b/src/pull-down-refresh/PullDownRefresh.tsx
@@ -124,7 +124,7 @@ const PullDownRefresh: React.FC<PullDownRefreshProps> = (originProps) => {
         new Promise((resolve) => {
           timeoutTid = setTimeout(() => {
             resolve(timeoutId);
-            onTimeout();
+            onTimeout?.();
           }, refreshTimeout);
         }),
       ]);
@@ -141,7 +141,7 @@ const PullDownRefresh: React.FC<PullDownRefreshProps> = (originProps) => {
     }
   };
 
-  const statusText = getStatusText(status, loadingTexts.length ? loadingTexts : (t(locale.loadingTexts) as string[]));
+  const statusText = getStatusText(status, loadingTexts?.length ? loadingTexts : (t(locale.loadingTexts) as string[]));
   let statusNode: React.ReactNode = <div className={`${name}__text`}>{statusText}</div>;
   if (status === PullStatusEnum.loading) {
     statusNode = <Loading text={statusText} size="24px" {...loadingProps} />;
@@ -194,7 +194,6 @@ const PullDownRefresh: React.FC<PullDownRefreshProps> = (originProps) => {
 
     if (status === PullStatusEnum.loosing) {
       doRefresh();
-      props.onRefresh?.();
     } else {
       setDistance(0);
     }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #929 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(PullDownRefresh): 修复 `onRefresh` 事件重复触发的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
